### PR TITLE
Junit4 to Junit5 Migration & Fixed TCs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,12 @@ subprojects {
     testLogging {
       showStandardStreams = false
       exceptionFormat = 'full'
+      afterSuite { desc, result ->
+        if (!desc.parent) {
+          println "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+          println "Report file: ${reports.html.entryPoint}"
+        }
+      }
     }
     minHeapSize = "512m"
     maxHeapSize = "512m"

--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -30,7 +30,6 @@ dependencies {
   testImplementation 'uk.org.webcompere:system-stubs-jupiter:1.2.0'
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
   testImplementation 'org.junit.jupiter:junit-jupiter-params'
-  testImplementation 'org.junit.platform:junit-platform-runner'
   testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
   testImplementation 'org.springframework:spring-test'
 

--- a/halyard-cli/src/test/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommandTest.java
+++ b/halyard-cli/src/test/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommandTest.java
@@ -33,10 +33,7 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 class HalCommandTest {
 
   private HalCommand hal;

--- a/halyard-config/src/test/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccountTest.java
+++ b/halyard-config/src/test/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccountTest.java
@@ -24,18 +24,8 @@ import com.netflix.spinnaker.halyard.config.config.v1.StrictObjectMapper;
 import java.io.IOException;
 import java.io.StringWriter;
 import org.junit.jupiter.api.Test;
-// import org.junit.platform.runner.JUnitPlatform;
-// import org.junit.runner.RunWith;
 import org.yaml.snakeyaml.Yaml;
 
-/*
-You don't need it anymore when using junit 5.
-In the junit documentation https://junit.org/junit5/docs/5.0.1/api/org/junit/platform/runner/JUnitPlatform.html
-it states:
-Annotating a class with @RunWith(JUnitPlatform.class) allows it to be run with IDEs and build systems that
-support JUnit 4 but do not yet support the JUnit Platform directly.
-*/
-// @RunWith(JUnitPlatform.class)
 final class KubernetesAccountTest {
 
   @Test

--- a/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/resource/v1/LocalDiskProfileReaderSpec.groovy
+++ b/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/resource/v1/LocalDiskProfileReaderSpec.groovy
@@ -22,8 +22,6 @@ import org.apache.commons.compress.archivers.ArchiveException
 import org.apache.commons.compress.archivers.ArchiveStreamFactory
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.io.IOUtils
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.context.annotation.Import
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Specification
 

--- a/halyard-web/config/halyard.yml
+++ b/halyard-web/config/halyard.yml
@@ -35,3 +35,7 @@ backup:
 
 retrofit:
   logLevel: BASIC
+
+logging:
+  level:
+    root: DEBUG

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/config/v1/WebConfiguration.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/config/v1/WebConfiguration.java
@@ -7,8 +7,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfiguration implements WebMvcConfigurer {
 
-    @Override
-    public void configurePathMatch(PathMatchConfigurer configurer) {
-        configurer.setUseTrailingSlashMatch(true);
-    }
+  @Override
+  public void configurePathMatch(PathMatchConfigurer configurer) {
+    configurer.setUseTrailingSlashMatch(true);
+  }
 }


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-20809)
**Project Doc :** NA

""Feature :** Junit4 to Junit5 Migration

### How changes are verified
gradlew build & test -> successful

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** NA