### PR TITLE
OP-21877 Remove explicit google-guava version

### DIFF
--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation 'org.yaml:snakeyaml:2.0'
   implementation 'com.beust:jcommander:1.81'
   implementation 'org.nibor.autolink:autolink:0.10.0'
-  implementation 'com.google.guava:guava:32.1.1-jre'
+  implementation 'com.google.guava:guava'
 
   implementation project(':halyard-config')
   implementation project(':halyard-core')

--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -36,7 +36,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-cloud-config-server"
   implementation 'com.amazonaws:aws-java-sdk-core:1.11.534'
   implementation 'com.amazonaws:aws-java-sdk-s3:1.11.534'
-  implementation 'com.google.guava:guava:32.1.1-jre'
+  implementation 'com.google.guava:guava'
 
   implementation 'com.google.apis:google-api-services-compute:alpha-rev20200526-1.30.9'
   implementation 'com.google.apis:google-api-services-appengine:v1-rev92-1.25.0'

--- a/halyard-core/halyard-core.gradle
+++ b/halyard-core/halyard-core.gradle
@@ -26,7 +26,7 @@ dependencies {
     exclude group: 'org.apache.groovy', module: 'groovy'
   }
   implementation 'org.apache.groovy:groovy:4.0.9'
-  implementation 'com.google.guava:guava:32.1.1-jre'
+  implementation 'com.google.guava:guava'
 
   implementation 'org.yaml:snakeyaml:2.0'
   implementation 'com.google.http-client:google-http-client-jackson2:+'

--- a/halyard-proto/halyard-proto.gradle
+++ b/halyard-proto/halyard-proto.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.google.protobuf'
 
 dependencies {
   implementation 'com.google.protobuf:protobuf-java'
-  implementation 'com.google.guava:guava:32.1.1-jre'
+  implementation 'com.google.guava:guava'
   api 'com.google.api.grpc:grpc-google-common-protos:1.0.5'
   implementation 'io.grpc:grpc-all:1.8.0'
 

--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -31,7 +31,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-config"
   runtimeOnly    "io.spinnaker.kork:kork-actuator"
   implementation "jakarta.validation:jakarta.validation-api:3.0.2"
-  implementation "com.google.guava:guava:32.1.1-jre"
+  implementation "com.google.guava:guava"
 
   implementation project(':halyard-backup')
   // halyard-cli is required as a dependency even though it is not used directly by halyard-web


### PR DESCRIPTION
**Jira** : https://devopsmx.atlassian.net/browse/OP-21877
**Summary** : Removed explicit version of com.google.guava version
**Testing** :
compile successful, no new TCs failed bcoz of this.
publish local maven, did DI on halyard, piucking latest version as mentioned in kork 
service started successfully after this change.

**Pre_merge** : NA
**Post_merge** : QA regression testing